### PR TITLE
Turn off hardware modulation when signal is low

### DIFF
--- a/hardware_modulation.py
+++ b/hardware_modulation.py
@@ -14,7 +14,7 @@ class modulator(object):
         self.pi.hardware_PWM(18, freq, duty_cycle)
 
     def clear(self):
-        self.pi.wave_clear()
+`       self.pi.hardware_PWM(18, 1, 0)
 
     def stop(self):
         self.pi.stop()

--- a/transmitter.py
+++ b/transmitter.py
@@ -17,10 +17,10 @@ try:
             if i == 1:
                 modulator.start()
                 GPIO.output(led_pin, GPIO.HIGH)
-                time.sleep(0.0005625)
+                time.sleep(0.0005625) #562.5 us
                 modulator.clear()
                 GPIO.output(led_pin, GPIO.LOW)
-                time.sleep(0.0016875)
+                time.sleep(0.0016875) #1.6875 ms
             else:
                 modulator.clear()
                 GPIO.output(led_pin, GPIO.LOW)

--- a/transmitter.py
+++ b/transmitter.py
@@ -1,0 +1,31 @@
+import RPi.GPIO as GPIO
+import hardware_modulation
+import time
+
+GPIO.setmode(GPIO.BCM)
+
+led_pin = 23
+
+GPIO.setup(led_pin, GPIO.OUT)
+
+test_transmit = [1, 1, 0, 1, 1]
+modulator = hardware_modulation.modulator()
+
+try:
+    while True:
+        for i in test_transmit:
+            if i == 1:
+                modulator.start()
+                GPIO.output(led_pin, GPIO.HIGH)
+                time.sleep(0.0005625)
+                modulator.clear()
+                GPIO.output(led_pin, GPIO.LOW)
+                time.sleep(0.0016875)
+            else:
+                modulator.clear()
+                GPIO.output(led_pin, GPIO.LOW)
+                time.sleep(0.00125) #1.125 ms
+except KeyboardInterrupt:
+    GPIO.cleanup()
+    modulator.stop()
+


### PR DESCRIPTION
#### Changes

- Set hardware PWM to have a duty cycle of 0 when clear() function called.